### PR TITLE
GraphiteReporter init log template wasn't filling

### DIFF
--- a/kafka-graphite-clients/src/main/java/org/apache/kafka/common/metrics/GraphiteReporter.java
+++ b/kafka-graphite-clients/src/main/java/org/apache/kafka/common/metrics/GraphiteReporter.java
@@ -79,7 +79,7 @@ public class GraphiteReporter implements MetricsReporter, Runnable {
             for (final KafkaMetric metric : metrics) {
                 metricList.add(metric);
             }
-            log.info("Configuring Kafka Graphite Reporter with host=%s, port=%d, prefix=%s and include=%s, exclude=%s",
+            log.info("Configuring Kafka Graphite Reporter with host={}, port={}, prefix={} and include={}, exclude={}",
                     hostname, port, prefix, includeRegex, excludeRegex);
             executor.scheduleAtFixedRate(this, interval, interval, TimeUnit.SECONDS);
         }


### PR DESCRIPTION
The INFO-level log statement in `GraphiteReporter` was appearing as a literal "org.apache.kafka.common.metrics.GraphiteReporter: Configuring Kafka Graphite Reporter with host=%s, port=%d, prefix=%s and include=%s, exclude=%s" rather than being populated with the values. Switching to sl4j's `{}` template syntax.
